### PR TITLE
Disable demo resources from Atea Community Trondheim to cut cost

### DIFF
--- a/infra/azure-landing-zones/lib/policy_assignments/policy_assignment_es_enforce_mandatory_tagging.json
+++ b/infra/azure-landing-zones/lib/policy_assignments/policy_assignment_es_enforce_mandatory_tagging.json
@@ -8,10 +8,10 @@
     "notScopes": [],
     "parameters": {
       "EnforceRGTags-costcenter": {
-        "Value": "costcenter"
+        "value": "costcenter"
       },
       "EnforceRGTags-owner": {
-        "Value": "owner"
+        "value": "owner"
       }
     },
     "policyDefinitionId": "${root_scope_resource_id}/providers/Microsoft.Authorization/policySetDefinitions/Enforce-Mandatory-Tags",

--- a/infra/azure-landing-zones/networkmanager.tf
+++ b/infra/azure-landing-zones/networkmanager.tf
@@ -1,4 +1,4 @@
-module "naming" {
+/* module "naming" {
   source  = "Azure/naming/azurerm"
   version = "~> 0.4"
   suffix  = [var.root_id]
@@ -78,4 +78,4 @@ resource "azurerm_network_manager_deployment" "connectivity" {
   configuration_ids = [
     azurerm_network_manager_connectivity_configuration.hub_spoke.id
   ]
-}
+} */

--- a/infra/azure-landing-zones/settings.connectivity.tf
+++ b/infra/azure-landing-zones/settings.connectivity.tf
@@ -30,7 +30,7 @@ locals {
               }
             }
             azure_firewall = {
-              enabled = true
+              enabled = false
               config = {
                 address_prefix                = "10.42.1.0/24"
                 enable_dns_proxy              = true


### PR DESCRIPTION
Comment out the Network Manager resources and set Firewall deployment to false after the demo session at Atea Community Trondheim.

Purely a cost optimization change =)

- **remove network manager and azure firewall to save costs**
- **fix casing in policy assignment for mandatory tags**
