### PR TITLE
Fix #49 to set budget in config file from issue

### DIFF
--- a/.github/workflows/add-new-lz.yml
+++ b/.github/workflows/add-new-lz.yml
@@ -44,7 +44,7 @@ jobs:
           name: ${{ steps.issue_title.outputs.title }}
           subscription_id: ${{ fromJson(steps.parse_issue.outputs.json).subscription_id }}
           subscription_type: ${{ fromJson(steps.parse_issue.outputs.json).archetype }}
-          budget_amount: ${{ fromJson(steps.parse_issue.outputs.json).budget_amount }}
+          budget_amount: ${{ fromJson(steps.parse_issue.outputs.json).budget }}
           virtual_networks:
             vnet1:
               address_space:


### PR DESCRIPTION
The issue template use the key "budget", and that key is parsed correctly by the github workflow, however the configbuilder step of the workflow refers to the key "budget_amount" that does not exist
