### PR TITLE
Deploy user assigned managed identity to landingzone

### DIFF
--- a/infra/subscription-vending-machine/README.md
+++ b/infra/subscription-vending-machine/README.md
@@ -20,6 +20,7 @@ The following requirements are needed by this module:
 
 The following resources are used by this module:
 
+- [azuread_group.owner](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/resources/group) (resource)
 - [azurerm_virtual_network.hub](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/virtual_network) (data source)
 
 <!-- markdownlint-disable MD013 -->

--- a/infra/subscription-vending-machine/main.tf
+++ b/infra/subscription-vending-machine/main.tf
@@ -82,4 +82,12 @@ module "lz_vending" {
       }
     }
   }
+
+  umi_enabled             = true
+  umi_name                = "id-${each.value.name}"
+  umi_resource_group_name = "rg-${each.value.name}-identity"
+  umi_resource_group_tags = {
+    costcenter = "platform"
+    owner      = "community-demo@ateaacfs.onmicrosoft.com"
+  }
 }


### PR DESCRIPTION
Fix #30 

This pull request includes updates to the `infra/subscription-vending-machine` module, enhancing its documentation and configuration. The most important changes include adding a new resource reference to the README and updating the Terraform configuration to enable and configure a user-managed identity (UMI).

Documentation update:

* [`infra/subscription-vending-machine/README.md`](diffhunk://#diff-a0b77b0ed05ebbff4c27c30c6388d02c7fac536c6e73334c99dd5338d1939269R23): Added a reference to the `azuread_group.owner` resource in the list of resources used by the module.

Terraform configuration update:

* [`infra/subscription-vending-machine/main.tf`](diffhunk://#diff-7c10d458791f4f1c2acd5bdb10000c14a84b6f3c033605dc7bb63f8ab39a3dc8R85-R92): Added configuration for enabling and setting up a user-managed identity (UMI), including specifying the UMI name, resource group name, and resource group tags.