### PR TITLE
Fix outbound internet access from Kubernetes cluster

### DIFF
--- a/workload/azure-kubernetes-service/README.md
+++ b/workload/azure-kubernetes-service/README.md
@@ -1,7 +1,7 @@
 <!-- BEGIN_TF_DOCS -->
 # Azure Kubernetes Service
 
-Denne demoen bruker [avm-ptn-aks-production](https://registry.terraform.io/modules/Azure/avm-ptn-aks-production/azurerm/latest), samt støtte-moduler for nettverk og logging fra [Azure Verified Modules](https://azure.github.io/Azure-Verified-Modules/) til å sette opp Kubernetes-clustre for både test og produksjon
+Denne demoen bruker [avm-ptn-aks-production](https://registry.terraform.io/modules/Azure/avm-ptn-aks-production/azurerm/latest), samt støtte-moduler for nettverk og logging, fra [Azure Verified Modules](https://azure.github.io/Azure-Verified-Modules/) til å sette opp Kubernetes-clustre for både test og produksjon
 
 <!-- markdownlint-disable MD033 -->
 ## Requirements

--- a/workload/azure-kubernetes-service/main.tf
+++ b/workload/azure-kubernetes-service/main.tf
@@ -82,6 +82,12 @@ module "nat_gateway" {
 
   enable_telemetry = var.enable_telemetry
 
+  public_ips = {
+    pip-1 = {
+      name = "ip-nat-gw-1"
+    }
+  }
+
   tags = merge(local.tags, {
     environment = each.key
   })
@@ -139,6 +145,7 @@ module "network" {
       address_prefixes = [
         cidrsubnet(each.value.address_space, 8, 0)
       ]
+      default_outbound_access_enabled = true
       nat_gateway = {
         id = module.nat_gateway[each.key].resource_id
       }
@@ -151,6 +158,7 @@ module "network" {
       address_prefixes = [
         cidrsubnet(each.value.address_space, 8, 1)
       ]
+      default_outbound_access_enabled = true
       nat_gateway = {
         id = module.nat_gateway[each.key].resource_id
       }

--- a/workload/azure-kubernetes-service/main.tf
+++ b/workload/azure-kubernetes-service/main.tf
@@ -145,7 +145,6 @@ module "network" {
       address_prefixes = [
         cidrsubnet(each.value.address_space, 8, 0)
       ]
-      default_outbound_access_enabled = true
       nat_gateway = {
         id = module.nat_gateway[each.key].resource_id
       }
@@ -158,7 +157,6 @@ module "network" {
       address_prefixes = [
         cidrsubnet(each.value.address_space, 8, 1)
       ]
-      default_outbound_access_enabled = true
       nat_gateway = {
         id = module.nat_gateway[each.key].resource_id
       }


### PR DESCRIPTION
This pull request includes updates to the `workload/azure-kubernetes-service` module to enhance documentation and configuration for Azure Kubernetes Service. The most important changes include improving the README for clarity and adding public IP configuration to the NAT gateway module.

Documentation improvements:

* [`workload/azure-kubernetes-service/README.md`](diffhunk://#diff-3f4b058e01289dd6aff318a87060e8451a8e666595566aa6a3327603534f0935L4-R4): Improved the clarity of the README by adding a comma to separate support modules for networking and logging.

Configuration enhancements:

* [`workload/azure-kubernetes-service/main.tf`](diffhunk://#diff-0307f34bb1418080aae4539b62ceb54d96221023424fc504e127d2e906f47247R85-R90): Added public IP configuration to the `nat_gateway` module to specify the name of the NAT gateway public IP.